### PR TITLE
Fixing typo endcode->encode

### DIFF
--- a/mcpi/connection.py
+++ b/mcpi/connection.py
@@ -35,7 +35,7 @@ class Connection:
         #print "s",s
         self.drain()
         self.lastSent = s
-        self.socket.sendall(s.endcode('utf-8'))
+        self.socket.sendall(s.encode('utf-8'))
 
     def receive(self):
         """Receives data. Note that the trailing newline '\n' is trimmed"""


### PR DESCRIPTION
The previous type casting typo broke the build, now updated and working.